### PR TITLE
Improve the script for running benchmark instances

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,4 @@
+#! /bin/bash
 j=3
 while true
 do

--- a/test.sh
+++ b/test.sh
@@ -1,11 +1,13 @@
 #! /bin/bash
+Z3=z3
+HOICE=hoice
 j=3
 while true
 do
 	./src/main int $1 $j
-	z3 experiment/out_int.smt2 > experiment/result_int
+	$Z3 experiment/out_int.smt2 > experiment/result_int
 	./src/main fv $1 0
-	z3 experiment/out_fv.smt2 > experiment/result
+	$Z3 experiment/out_fv.smt2 > experiment/result
 	st=`head -n 1 experiment/result`
 	if [ $st = "sat" ] ; then
 		break
@@ -15,7 +17,7 @@ done
 echo "range: $j"
 echo "ownership: $st"
 ./src/main chc $1 0
-hoice experiment/out_chc.smt2 > experiment/chc_result
+$HOICE experiment/out_chc.smt2 > experiment/chc_result
 st2=`head -n 1 experiment/chc_result` 
 echo "refinement: $st2"
 echo ""

--- a/test_all.sh
+++ b/test_all.sh
@@ -6,3 +6,4 @@ for file in examples/bench/*; do
     fi
     echo ""
 done
+#! /bin/bash

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,9 +1,39 @@
-for file in examples/bench/*; do
-    echo "$file:"
-    time -p timeout 180 ./test.sh $file
-    if [ $? -ne 0 ]; then
-        echo "Timeout"
-    fi
-    echo ""
-done
 #! /bin/bash
+
+function verbose (){
+    for file in examples/bench/*; do
+        echo "$file:"
+        time -p timeout 180 ./test.sh $file
+        if [ $? -ne 0 ]; then
+            echo "Timeout"
+        fi
+        echo ""
+    done
+}
+
+
+function gen_table(){
+    # Only shows the "real time"
+    TIMEFORMAT='%3R'
+    for file in examples/bench/*; do
+        # Ignores the output of test.sh
+        ret=$( { time timeout 180 ./test.sh $file >/dev/null ; } 2>&1 )
+        if [ $? -ne 0 ]; then
+            ret="Timeout"
+        fi
+        echo -e "$(basename -s .imp $file)\t${ret}"
+    done
+}
+
+case $1 in
+    -t)
+      gen_table
+      ;;
+    -*)
+      echo "invalid option"
+      exit 1
+      ;;
+    *)
+      verbose
+      ;;
+esac


### PR DESCRIPTION
Now `./test_all.sh -t` generates an output like
```
add_array	Timeout
copy_array	22.258
init_10	11.789
init	2.485
sum_back_noann	1.177
sum_both_noann	0.400
sum_noann	1.361
```
which is closer to the table reported in the paper.
(If the `-t` option is not given, then the script behaves as before)